### PR TITLE
Update to v5.x of terraform-provider-aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,63 +43,61 @@ Manager secret.
 [internal integration]: https://docs.sentry.io/product/integrations/integration-platform/internal-integration/
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version   |
-| ------------------------------------------------------------------------ | --------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0    |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
-| Name                                             | Version |
-| ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 5.0  |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
-| Name                                                        | Source                                                                | Version |
-| ----------------------------------------------------------- | --------------------------------------------------------------------- | ------- |
-| <a name="module_rotation"></a> [rotation](#module_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.8.0  |
-| <a name="module_secret"></a> [secret](#module_secret)       | github.com/thoughtbot/terraform-aws-secrets//secret                   | v0.8.0  |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.8.0 |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.8.0 |
 
 ## Resources
 
-| Name                                                                                                                                                       | Type        |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_iam_policy.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                 | resource    |
-| [aws_iam_role_policy_attachment.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource    |
-| [aws_security_group.function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group)                                  | resource    |
-| [aws_security_group_rule.function_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule)                 | resource    |
-| [aws_iam_policy_document.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)            | data source |
-| [aws_kms_key.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key)                                           | data source |
-| [aws_secretsmanager_secret.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret)               | data source |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_security_group.function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.function_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_iam_policy_document.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_key.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
+| [aws_secretsmanager_secret.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 
 ## Inputs
 
-| Name                                                                                                | Description                                                           | Type           | Default                     | Required |
-| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------- | --------------------------- | :------: |
-| <a name="input_admin_principals"></a> [admin_principals](#input_admin_principals)                   | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null`                      |    no    |
-| <a name="input_auth_token_kms_key_id"></a> [auth_token_kms_key_id](#input_auth_token_kms_key_id)    | ID of the KMS key used to encrypt the auth token                      | `string`       | `"alias/sentry-auth-token"` |    no    |
-| <a name="input_auth_token_secret_arn"></a> [auth_token_secret_arn](#input_auth_token_secret_arn)    | ARN of a SecretsManager secret containing a Sentry auth token         | `string`       | `null`                      |    no    |
-| <a name="input_auth_token_secret_key"></a> [auth_token_secret_key](#input_auth_token_secret_key)    | Key within secret at which the auth token ca be accessed              | `string`       | `"SENTRY_AUTH_TOKEN"`       |    no    |
-| <a name="input_auth_token_secret_name"></a> [auth_token_secret_name](#input_auth_token_secret_name) | Name of a SecretsManager secret containing a Sentry auth token        | `string`       | `"sentry-auth-token"`       |    no    |
-| <a name="input_name"></a> [name](#input_name)                                                       | Name for the Sentry client key                                        | `string`       | n/a                         |   yes    |
-| <a name="input_organization_slug"></a> [organization_slug](#input_organization_slug)                | Slug for the Sentry organization in which the project exists          | `string`       | n/a                         |   yes    |
-| <a name="input_project_slug"></a> [project_slug](#input_project_slug)                               | Slug for the Sentry project for which a key should be created         | `string`       | n/a                         |   yes    |
-| <a name="input_read_principals"></a> [read_principals](#input_read_principals)                      | Principals allowed to read the secret (default: current account)      | `list(string)` | `null`                      |    no    |
-| <a name="input_subnet_ids"></a> [subnet_ids](#input_subnet_ids)                                     | Subnets in which the rotation function should run                     | `list(string)` | n/a                         |   yes    |
-| <a name="input_tags"></a> [tags](#input_tags)                                                       | Tags which should be applied to created resources                     | `map(string)`  | `{}`                        |    no    |
-| <a name="input_trust_tags"></a> [trust_tags](#input_trust_tags)                                     | Tags required on principals accessing the secret                      | `map(string)`  | `{}`                        |    no    |
-| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id)                                                 | VPC in which the rotation function should run                         | `string`       | n/a                         |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_principals"></a> [admin\_principals](#input\_admin\_principals) | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null` | no |
+| <a name="input_auth_token_kms_key_id"></a> [auth\_token\_kms\_key\_id](#input\_auth\_token\_kms\_key\_id) | ID of the KMS key used to encrypt the auth token | `string` | `"alias/sentry-auth-token"` | no |
+| <a name="input_auth_token_secret_arn"></a> [auth\_token\_secret\_arn](#input\_auth\_token\_secret\_arn) | ARN of a SecretsManager secret containing a Sentry auth token | `string` | `null` | no |
+| <a name="input_auth_token_secret_key"></a> [auth\_token\_secret\_key](#input\_auth\_token\_secret\_key) | Key within secret at which the auth token ca be accessed | `string` | `"SENTRY_AUTH_TOKEN"` | no |
+| <a name="input_auth_token_secret_name"></a> [auth\_token\_secret\_name](#input\_auth\_token\_secret\_name) | Name of a SecretsManager secret containing a Sentry auth token | `string` | `"sentry-auth-token"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for the Sentry client key | `string` | n/a | yes |
+| <a name="input_organization_slug"></a> [organization\_slug](#input\_organization\_slug) | Slug for the Sentry organization in which the project exists | `string` | n/a | yes |
+| <a name="input_project_slug"></a> [project\_slug](#input\_project\_slug) | Slug for the Sentry project for which a key should be created | `string` | n/a | yes |
+| <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principals allowed to read the secret (default: current account) | `list(string)` | `null` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which the rotation function should run | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags which should be applied to created resources | `map(string)` | `{}` | no |
+| <a name="input_trust_tags"></a> [trust\_tags](#input\_trust\_tags) | Tags required on principals accessing the secret | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC in which the rotation function should run | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                 | Description                                               |
-| -------------------------------------------------------------------- | --------------------------------------------------------- |
-| <a name="output_policy_json"></a> [policy_json](#output_policy_json) | Required IAM policies                                     |
-| <a name="output_secret_arn"></a> [secret_arn](#output_secret_arn)    | ARN of the secrets manager secret containing credentials  |
-| <a name="output_secret_name"></a> [secret_name](#output_secret_name) | Name of the secrets manager secret containing credentials |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_policy_json"></a> [policy\_json](#output\_policy\_json) | Required IAM policies |
+| <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the secrets manager secret containing credentials |
+| <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | Name of the secrets manager secret containing credentials |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The recommended approach to generating an auth token is to create an [internal
 integration] for Sentry. In order to manage auth tokens, you will need the
 following scopes:
 
-* `project:read`
-* `project:write`
-* `project:admin`
+- `project:read`
+- `project:write`
+- `project:admin`
 
 After creating the integration, copy the auth token and save it in a Secrets
 Manager secret.
@@ -43,61 +43,63 @@ Manager secret.
 [internal integration]: https://docs.sentry.io/product/integrations/integration-platform/internal-integration/
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| Name                                                                     | Version   |
+| ------------------------------------------------------------------------ | --------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0    |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| Name                                             | Version |
+| ------------------------------------------------ | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 5.0  |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.4.0 |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.4.0 |
+| Name                                                        | Source                                                                | Version |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- | ------- |
+| <a name="module_rotation"></a> [rotation](#module_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.8.0  |
+| <a name="module_secret"></a> [secret](#module_secret)       | github.com/thoughtbot/terraform-aws-secrets//secret                   | v0.8.0  |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_policy.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role_policy_attachment.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_security_group.function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.function_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_iam_policy_document.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_kms_key.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
-| [aws_secretsmanager_secret.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| Name                                                                                                                                                       | Type        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_iam_policy.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                 | resource    |
+| [aws_iam_role_policy_attachment.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource    |
+| [aws_security_group.function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group)                                  | resource    |
+| [aws_security_group_rule.function_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule)                 | resource    |
+| [aws_iam_policy_document.access_auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)            | data source |
+| [aws_kms_key.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key)                                           | data source |
+| [aws_secretsmanager_secret.auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret)               | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_admin_principals"></a> [admin\_principals](#input\_admin\_principals) | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null` | no |
-| <a name="input_auth_token_kms_key_id"></a> [auth\_token\_kms\_key\_id](#input\_auth\_token\_kms\_key\_id) | ID of the KMS key used to encrypt the auth token | `string` | `"alias/sentry-auth-token"` | no |
-| <a name="input_auth_token_secret_arn"></a> [auth\_token\_secret\_arn](#input\_auth\_token\_secret\_arn) | ARN of a SecretsManager secret containing a Sentry auth token | `string` | `null` | no |
-| <a name="input_auth_token_secret_key"></a> [auth\_token\_secret\_key](#input\_auth\_token\_secret\_key) | Key within secret at which the auth token ca be accessed | `string` | `"SENTRY_AUTH_TOKEN"` | no |
-| <a name="input_auth_token_secret_name"></a> [auth\_token\_secret\_name](#input\_auth\_token\_secret\_name) | Name of a SecretsManager secret containing a Sentry auth token | `string` | `"sentry-auth-token"` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name for the Sentry client key | `string` | n/a | yes |
-| <a name="input_organization_slug"></a> [organization\_slug](#input\_organization\_slug) | Slug for the Sentry organization in which the project exists | `string` | n/a | yes |
-| <a name="input_project_slug"></a> [project\_slug](#input\_project\_slug) | Slug for the Sentry project for which a key should be created | `string` | n/a | yes |
-| <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principals allowed to read the secret (default: current account) | `list(string)` | `null` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which the rotation function should run | `list(string)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags which should be applied to created resources | `map(string)` | `{}` | no |
-| <a name="input_trust_tags"></a> [trust\_tags](#input\_trust\_tags) | Tags required on principals accessing the secret | `map(string)` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC in which the rotation function should run | `string` | n/a | yes |
+| Name                                                                                                | Description                                                           | Type           | Default                     | Required |
+| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------- | --------------------------- | :------: |
+| <a name="input_admin_principals"></a> [admin_principals](#input_admin_principals)                   | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null`                      |    no    |
+| <a name="input_auth_token_kms_key_id"></a> [auth_token_kms_key_id](#input_auth_token_kms_key_id)    | ID of the KMS key used to encrypt the auth token                      | `string`       | `"alias/sentry-auth-token"` |    no    |
+| <a name="input_auth_token_secret_arn"></a> [auth_token_secret_arn](#input_auth_token_secret_arn)    | ARN of a SecretsManager secret containing a Sentry auth token         | `string`       | `null`                      |    no    |
+| <a name="input_auth_token_secret_key"></a> [auth_token_secret_key](#input_auth_token_secret_key)    | Key within secret at which the auth token ca be accessed              | `string`       | `"SENTRY_AUTH_TOKEN"`       |    no    |
+| <a name="input_auth_token_secret_name"></a> [auth_token_secret_name](#input_auth_token_secret_name) | Name of a SecretsManager secret containing a Sentry auth token        | `string`       | `"sentry-auth-token"`       |    no    |
+| <a name="input_name"></a> [name](#input_name)                                                       | Name for the Sentry client key                                        | `string`       | n/a                         |   yes    |
+| <a name="input_organization_slug"></a> [organization_slug](#input_organization_slug)                | Slug for the Sentry organization in which the project exists          | `string`       | n/a                         |   yes    |
+| <a name="input_project_slug"></a> [project_slug](#input_project_slug)                               | Slug for the Sentry project for which a key should be created         | `string`       | n/a                         |   yes    |
+| <a name="input_read_principals"></a> [read_principals](#input_read_principals)                      | Principals allowed to read the secret (default: current account)      | `list(string)` | `null`                      |    no    |
+| <a name="input_subnet_ids"></a> [subnet_ids](#input_subnet_ids)                                     | Subnets in which the rotation function should run                     | `list(string)` | n/a                         |   yes    |
+| <a name="input_tags"></a> [tags](#input_tags)                                                       | Tags which should be applied to created resources                     | `map(string)`  | `{}`                        |    no    |
+| <a name="input_trust_tags"></a> [trust_tags](#input_trust_tags)                                     | Tags required on principals accessing the secret                      | `map(string)`  | `{}`                        |    no    |
+| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id)                                                 | VPC in which the rotation function should run                         | `string`       | n/a                         |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_policy_json"></a> [policy\_json](#output\_policy\_json) | Required IAM policies |
-| <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the secrets manager secret containing credentials |
-| <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | Name of the secrets manager secret containing credentials |
+| Name                                                                 | Description                                               |
+| -------------------------------------------------------------------- | --------------------------------------------------------- |
+| <a name="output_policy_json"></a> [policy_json](#output_policy_json) | Required IAM policies                                     |
+| <a name="output_secret_arn"></a> [secret_arn](#output_secret_arn)    | ARN of the secrets manager secret containing credentials  |
+| <a name="output_secret_name"></a> [secret_name](#output_secret_name) | Name of the secrets manager secret containing credentials |
+
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Sentry DSN: ${var.name}"
@@ -15,7 +15,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler            = "lambda_function.lambda_handler"
   role_arn           = module.secret.rotation_role_arn

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
Switch this and dependent modules to the v5.x of the Terraform AWS
provider to support the latest AWS features, like RDS' io2.